### PR TITLE
Add junit tests for reflection commands

### DIFF
--- a/src/test/java/commands/reflectcommands/GetReflectionQuestionsCommandTest.java
+++ b/src/test/java/commands/reflectcommands/GetReflectionQuestionsCommandTest.java
@@ -1,0 +1,39 @@
+package commands.reflectcommands;
+
+import exceptions.ReflectException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reflection.ReflectionManager;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class GetReflectionQuestionsCommandTest {
+
+    private ReflectionManager reflectionManager;
+    private GetReflectionQuestionsCommand command;
+
+    @BeforeEach
+    void setUp() throws ReflectException {
+        reflectionManager = new ReflectionManager();
+        command = new GetReflectionQuestionsCommand(reflectionManager, "");
+    }
+
+    @Test
+    void constructor_emptyArgs_noExceptionThrown() {
+        assertDoesNotThrow(() -> new GetReflectionQuestionsCommand(reflectionManager, ""));
+    }
+
+    @Test
+    void constructor_nonEmptyArgs_exceptionThrown() {
+        assertThrows(ReflectException.class, () -> new GetReflectionQuestionsCommand(reflectionManager, "args"));
+    }
+
+
+    @Test
+    void isExit_notExitCommand_returnFalse() {
+        assertFalse(command.isExit());
+    }
+}
+

--- a/src/test/java/commands/reflectcommands/ListFavouriteReflectionsCommandTest.java
+++ b/src/test/java/commands/reflectcommands/ListFavouriteReflectionsCommandTest.java
@@ -1,0 +1,37 @@
+package commands.reflectcommands;
+
+import exceptions.ReflectException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reflection.ReflectionManager;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class ListFavouriteReflectionsCommandTest {
+    private ReflectionManager reflectionManager;
+    private ListFavouriteReflectionsCommand command;
+
+    @BeforeEach
+    void setUp() throws ReflectException {
+        reflectionManager = new ReflectionManager();
+        command = new ListFavouriteReflectionsCommand(reflectionManager, "");
+    }
+
+    @Test
+    void constructor_emptyArgs_noExceptionThrown() {
+        assertDoesNotThrow(() -> new ListFavouriteReflectionsCommand(reflectionManager, ""));
+    }
+
+    @Test
+    void constructor_nonEmptyArgs_exceptionThrown() {
+        assertThrows(ReflectException.class, () -> new ListFavouriteReflectionsCommand(reflectionManager, "args"));
+    }
+
+    @Test
+    void isExit_notExitCommand_returnFalse() {
+        assertFalse(command.isExit());
+    }
+}
+

--- a/src/test/java/commands/reflectcommands/ReflectionHelpCommandTest.java
+++ b/src/test/java/commands/reflectcommands/ReflectionHelpCommandTest.java
@@ -1,0 +1,37 @@
+package commands.reflectcommands;
+
+import exceptions.ReflectException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reflection.ReflectionManager;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class ReflectionHelpCommandTest {
+
+    private ReflectionManager reflectionManager;
+    private ReflectionHelpCommand command;
+
+    @BeforeEach
+    void setUp() throws ReflectException {
+        reflectionManager = new ReflectionManager();
+        command = new ReflectionHelpCommand(reflectionManager, "");
+    }
+
+    @Test
+    void constructor_emptyArgs_noExceptionThrown() {
+        assertDoesNotThrow(() -> new ReflectionHelpCommand(reflectionManager, ""));
+    }
+
+    @Test
+    void constructor_nonEmptyArgs_exceptionThrown() {
+        assertThrows(ReflectException.class, () -> new ReflectionHelpCommand(reflectionManager, "args"));
+    }
+
+    @Test
+    void isExit_notExitCommand_returnFalse() {
+        assertFalse(command.isExit());
+    }
+}

--- a/src/test/java/commands/reflectcommands/SaveToFavouritesCommandTest.java
+++ b/src/test/java/commands/reflectcommands/SaveToFavouritesCommandTest.java
@@ -1,0 +1,31 @@
+package commands.reflectcommands;
+
+import exceptions.ReflectException;
+import org.junit.jupiter.api.Test;
+import reflection.ReflectionManager;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class SaveToFavouritesCommandTest {
+
+    @Test
+    void constructor_validReflectionId_success() {
+        ReflectionManager reflectionManager = new ReflectionManager();
+        assertDoesNotThrow(() -> new SaveToFavouritesCommand(reflectionManager, "1"));
+    }
+
+    @Test
+    void constructor_invalidReflectionId_throwReflectException() {
+        ReflectionManager reflectionManager = new ReflectionManager();
+        assertThrows(ReflectException.class, () -> new SaveToFavouritesCommand(reflectionManager, "invalidId"));
+    }
+
+    @Test
+    void testIsExit() throws ReflectException {
+        ReflectionManager reflectionManager = new ReflectionManager();
+        SaveToFavouritesCommand saveCommand = new SaveToFavouritesCommand(reflectionManager, "1");
+        assertFalse(saveCommand.isExit());
+    }
+}

--- a/src/test/java/commands/reflectcommands/UnsaveFromFavouritesCommandTest.java
+++ b/src/test/java/commands/reflectcommands/UnsaveFromFavouritesCommandTest.java
@@ -1,0 +1,30 @@
+package commands.reflectcommands;
+
+import exceptions.ReflectException;
+import org.junit.jupiter.api.Test;
+import reflection.ReflectionManager;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class UnsaveFromFavouritesCommandTest {
+    @Test
+    void constructor_validReflectionId_success() {
+        ReflectionManager reflectionManager = new ReflectionManager();
+        assertDoesNotThrow(() -> new UnsaveFromFavouritesCommand(reflectionManager, "1"));
+    }
+
+    @Test
+    void constructor_invalidReflectionId_throwReflectException() {
+        ReflectionManager reflectionManager = new ReflectionManager();
+        assertThrows(ReflectException.class, () -> new UnsaveFromFavouritesCommand(reflectionManager, "invalidId"));
+    }
+
+    @Test
+    void testIsExit() throws ReflectException {
+        ReflectionManager reflectionManager = new ReflectionManager();
+        UnsaveFromFavouritesCommand saveCommand = new UnsaveFromFavouritesCommand(reflectionManager, "1");
+        assertFalse(saveCommand.isExit());
+    }
+}


### PR DESCRIPTION
Let's
* Focus on testing constructors and checking of exit flags
* Exclude calling on execution as it will become a repetition of testing methods in reflection manager class